### PR TITLE
feat: add --prod flag to limit audit to production dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Emit vulnerabilities inline in the workflow logs using GitHub annotations'
     required: false
     default: false
+  prod:
+    description: 'Only audit production dependencies (excludes devDependencies)'
+    required: false
+    default: false
 
 runs:
   using: node20

--- a/dist/index.js
+++ b/dist/index.js
@@ -30009,7 +30009,8 @@ const main = () => __awaiter(void 0, void 0, void 0, function* () {
     const packageJsonPath = (0, core_1.getInput)("package_json_path");
     const singleComment = (0, core_1.getBooleanInput)("single_comment");
     const inline = (0, core_1.getBooleanInput)("inline");
-    const input = `pnpm audit --audit-level="${level !== "" ? level : "critical"}" --json`;
+    const prod = (0, core_1.getBooleanInput)("prod");
+    const input = `pnpm audit --audit-level="${level !== "" ? level : "critical"}" --json${prod ? " --prod" : ""}`;
     const fails = (0, core_1.getBooleanInput)("fails");
     if (github_1.context.payload.pull_request == null) {
         (0, core_1.setFailed)("No pull request found.");

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ To use this action, add the following step to your workflow file:
         fails: true # true to fail the build if vulnerabilities are found
         single_comment: false # true to only post one comment
         inline: false # true to emit audit findings directly in the workflow logs using GitHub annotation syntax
+        prod: false # true to only audit production dependencies (excludes devDependencies)
 ```
 
 ## Inputs
@@ -61,6 +62,12 @@ Default: `false`
 Emit audit findings directly in the workflow logs using GitHub annotation
 syntax. When enabled, the action surfaces each vulnerability inline so they are
 visible without opening the pull request comment.
+
+Default: `false`
+
+### `prod`
+Only audit production dependencies. When enabled, appends `--prod` to the
+`pnpm audit` command, excluding `devDependencies` from the audit results.
 
 Default: `false`
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,8 +141,9 @@ const main = async (): Promise<void> => {
   const packageJsonPath = getInput("package_json_path");
   const singleComment = getBooleanInput("single_comment");
   const inline = getBooleanInput("inline");
+  const prod = getBooleanInput("prod");
   const input = `pnpm audit --audit-level="${level !== "" ? level : "critical"
-    }" --json`;
+    }" --json${prod ? " --prod" : ""}`;
   const fails = getBooleanInput("fails");
   if (context.payload.pull_request == null) {
     setFailed("No pull request found.");


### PR DESCRIPTION
## Summary

Closes #10 — implements the `--prod` flag requested by @boly38.

- Adds a new `prod` boolean input to `action.yml` (default: `false`)
- When `prod: true`, appends `--prod` to the `pnpm audit` command to exclude `devDependencies` from the audit
- Documents the new input in `readme.md` (usage example + inputs section)

## Usage

```yaml
- uses: JamesRobertWiseman/pnpm-audit@v3
  with:
    level: critical
    prod: true  # only audit production dependencies
```

## Test plan

- [ ] Verify action runs successfully with `prod: false` (default — existing behaviour unchanged)
- [ ] Verify action runs with `prod: true` and that the generated `pnpm audit` command includes `--prod`